### PR TITLE
Fix: update ESPDetect to match new Detect signature

### DIFF
--- a/nn/modules/esp_head.py
+++ b/nn/modules/esp_head.py
@@ -13,7 +13,8 @@ __all__ = "ESPDetect"
 class ESPDetect(Detect):
     def __init__(self, nc=1, ch=()):
         """Initializes the ESP detection layer with specified number of classes and channels."""
-        super().__init__(nc, ch)
+        # Ultralytics Detect now takes (nc, reg_max, end2end, ch), so pass keywords.
+        super().__init__(nc=nc, reg_max=1, ch=ch)
         self.reg_max = 1
         self.no = nc + self.reg_max * 4  # number of outputs per anchor =9
 
@@ -44,4 +45,3 @@ class ESPDetect(Detect):
         score2 = self.cv3[2](x[2])
 
         return box0, score0, box1, score1, box2, score2
-


### PR DESCRIPTION
## Description

This PR fixes a build/runtime compatibility issue in `ESPDetect` when used with newer versions of Ultralytics under Python 3.8.

### Problem

`ESPDetect` currently calls the parent `Detect` constructor like this:

```python
super().__init__(nc, ch)
```

This relies on the older positional signature of `Detect`.

With newer Ultralytics versions, the `Detect` constructor signature has changed (now effectively including parameters like `nc`, `reg_max`, `end2end`, and `ch`). As a result, the `ch` argument is incorrectly passed as `reg_max`, which later causes the following error during model construction:

```python
TypeError: unsupported operand type(s) for +: 'int' and 'list'
```

### Fix

This PR updates the `ESPDetect` constructor to pass arguments by keyword instead of relying on the old positional order:

```python
super().__init__(nc=nc, reg_max=1, ch=ch)
```

This preserves the intended behavior of `ESPDetect` (`reg_max = 1`) while making it compatible with the newer `Detect` constructor.

### Why this change

Without this fix, the custom detection flow in `espdet_run.py` fails before training starts when using newer Ultralytics releases.

After applying this change, the workflow can proceed normally and generate the expected output.

---

## Related

Fixes #<issue-number>

Related commit in my fork:

* `8849f994761e05f3bafd2d783ec47a1dc63b9874` — `fix: update ESPDetect to match new Detect signature`

---

## Testing

I reproduced and verified this issue in both of the following environments:

* Windows (conda)
* Linux (`uv run python`)

Python version used in both environments:

* Python 3.8

Test command:

```bash
python espdet_run.py \
  --class_name mycat \
  --pretrained_path None \
  --dataset "cfg/datasets/coco_cat.yaml" \
  --size 224 224 \
  --target "esp32p4" \
  --calib_data "deploy/cat_calib" \
  --espdl "espdet_pico_224_224_mycat.espdl" \
  --img "espdet.jpg"
```

### Before this change

Model initialization fails with:

```bash
TypeError: unsupported operand type(s) for +: 'int' and 'list'
```

### After this change

The workflow proceeds past model construction successfully and continues as expected.

I also verified the generated model on `esp32p4eye`, and it produced valid detection output on device.

---

## Checklist

* [x] 🚨 This PR does not introduce breaking changes.
* [ ] All CI checks (GH Actions) pass.
* [ ] Documentation is updated as needed.
* [ ] Tests are updated or added as necessary.
* [x] Code is well-commented, especially in complex areas.
* [x] Git history is clean — commits are squashed to the minimum necessary.
